### PR TITLE
Replace active print statements with logging to stdout.

### DIFF
--- a/smpp/smsc.py
+++ b/smpp/smsc.py
@@ -1,6 +1,13 @@
+import logging
 import socket
 
 from esme import *
+
+
+logger = logging.getLogger(__name__)
+stdout_stream_handler = logging.StreamHandler(sys.stdout)
+logger.addHandler(stdout_stream_handler)
+logger.setLevel(logging.DEBUG)
 
 
 class SMSC(ESME): # this is a dummy SMSC, just for testing
@@ -11,7 +18,7 @@ class SMSC(ESME): # this is a dummy SMSC, just for testing
         self.server.bind(('', port))
         self.server.listen(1)
         self.conn, self.addr = self.server.accept()
-        print 'Connected by', self.addr
+        logger.info('Connected by %s', self.addr)
         while 1:
             pdu = self._ESME__recv()
             if not pdu: break


### PR DESCRIPTION
First of all, thanks for your work on this package. It is quite useful.

I'd like to create log files for it, and I think it would be helpful to capture all the messages that are currently output using print statements. So I replaced all the active print statements with logging ones.

I configured them to print to the stdout so that the output looks the same out of the box. But now users have the ability to configure the ESME and SMSC logging by using the logger names `smpp.esme` and `smpp.smsc` respectively.
