### PR TITLE
Message Length incorrectly set on some PDUs

### DIFF
--- a/smpp/pdu.py
+++ b/smpp/pdu.py
@@ -1046,7 +1046,6 @@ def encode_param_type(param, type, min=0, max=None, map=None):
         if len(hex) % 2:
             # pad odd length hex strings
             hex = '0' + hex
-    #print type, min, max, repr(param), hex, map
+    if None not in (max, hex) and len(hex) > 2 * max:
+        raise ValueError("Value exceeds maximum size of %s." % (max,))
     return hex
-
-

--- a/tests.py
+++ b/tests.py
@@ -291,13 +291,46 @@ class PduTestCase(unittest.TestCase):
             '0204000201ff',
             encode_optional_parameter('user_message_reference', 511))
 
+    def test_encode_param_type_no_value(self):
+        self.assertEqual(encode_param_type(None, 'integer'), None)
+        self.assertEqual(encode_param_type(None, 'string'), None)
+        self.assertEqual(encode_param_type(None, 'xstring'), None)
+        self.assertEqual(encode_param_type(None, 'bitmask'), None)
+        self.assertEqual(encode_param_type(None, 'hex'), None)
+
+    def test_encode_param_type_integer(self):
+        self.assertEqual(encode_param_type(0, 'integer'), '00')
+        self.assertEqual(encode_param_type(1, 'integer'), '01')
+        self.assertEqual(encode_param_type(255, 'integer'), 'ff')
+        self.assertEqual(encode_param_type(256, 'integer'), '0100')
+
+        self.assertEqual(encode_param_type(0, 'integer', min=2), '0000')
+        self.assertEqual(encode_param_type(255, 'integer', min=2), '00ff')
+        self.assertEqual(encode_param_type(256, 'integer', min=2), '0100')
+
+        self.assertEqual(encode_param_type(255, 'integer', max=1), 'ff')
+        self.assertRaises(ValueError, encode_param_type, 256, 'integer', max=1)
+
+    def test_encode_param_type_string(self):
+        self.assertEqual(encode_param_type('', 'string'), '00')
+        self.assertEqual(encode_param_type('ABC', 'string'), '41424300')
+        self.assertEqual(encode_param_type('ABC', 'string', max=4), '41424300')
+        self.assertRaises(
+            ValueError, encode_param_type, 'ABC', 'string', max=3)
+
+    def test_encode_param_type_xstring(self):
+        self.assertEqual(encode_param_type('', 'xstring'), '')
+        self.assertEqual(encode_param_type('ABC', 'xstring'), '414243')
+        self.assertEqual(encode_param_type('ABC', 'xstring', max=3), '414243')
+        self.assertRaises(
+            ValueError, encode_param_type, 'ABC', 'xstring', max=2)
+
 
 class PduBuilderTestCase(unittest.TestCase):
-
-    def test_true(self):
-        print ''
-        self.assertTrue(True)
-
+    def test_submit_sm_message_too_long(self):
+        short_message = '1234567890' * 26
+        submit_sm = SubmitSM(5, short_message=short_message)
+        self.assertRaises(ValueError, submit_sm.get_hex)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The log of our MT is available at request

```
At least i see message length is wrong:     Message length: 3. According to
you logs it is much longer.

Short Message Peer to Peer, Command: Submit_sm, Seq: 28722, Len: 944
    Length: 944
    Operation: Submit_sm (0x00000004)
    Sequence #: 28722
    Service type: (Default)
    Type of number (originator): Unknown (0x00)
    Numbering plan indicator (originator): Unknown (0x00)
    Originator address: 254731222093
    Type of number (recipient): International (0x01)
    Numbering plan indicator (recipient): ISDN (E163/E164) (0x01)
    Recipient address: 254787100382
    .... ..00 = Messaging mode: Default SMSC mode (0x00)
    ..00 00.. = Message type: Default message type (0x00)
    00.. .... = GSM features: No specific features selected (0x00)
    Protocol id.: 0x00
    Priority level: GSM: None      ANSI-136: Bulk         IS-95: Normal
(0x00)
    Scheduled delivery time: Immediate delivery
    Validity period: SMSC default validity period
    .... ..01 = Delivery receipt: Delivery receipt requested (for success
or failure) (0x01)
    .... 00.. = Message type: No recipient SME acknowledgement requested
(0x00)
    ...0 .... = Intermediate notif: No intermediate notification requested
(0x00)
    .... ...0 = Replace: Don't replace (0x00)
    Data coding: 0x08
        SMPP Data Coding Scheme: UCS2 (ISO/IEC-10646) (0x08)
        GSM SMS Data Coding
        0000 .... = DCS Coding Group for SMS: SMS DCS: General Data Coding
indication - Uncompressed text, no message class (0x00)
        ..0. .... = DCS Text compression: Uncompressed text
        ...0 .... = DCS Class present: No message class
        .... 10.. = DCS Character set: UCS-2 (16-bit) data (0x02)
        GSM CBS Data Coding
        0000 .... = DCS Coding Group for CBS: CBS DCS: Language using the
GSM 7-bit default alphabet (0x00)
        ..00 1000 = DCS CBS Message language: Portuguese (0x08)
    Predefined message: 0
    Message length: 3
    Message
    Optional parameters
        Optional parameter: 0x4100 (0x4100)
            Tag: 0x4100
            Length: 8192
[Malformed Packet: SMPP]
    [Expert Info (Error/Malformed): Malformed Packet (Exception occurred)]
        [Message: Malformed Packet (Exception occurred)]
        [Severity level: Error]
        [Group: Malformed]
```
